### PR TITLE
Remove the job earlier in the processing cycle

### DIFF
--- a/src/Handler/Laravel/Job.php
+++ b/src/Handler/Laravel/Job.php
@@ -55,11 +55,12 @@ class Job
      */
     public function fire(IlluminateJob $job, array $data)
     {
+        $job->delete();
+
         if (empty($this->transport)) {
             $this->transport = new $data['transport']['class']($data['transport']['options']);
         }
 
         $this->transport->send($data['url'], $data['data'], $data['headers']);
-        $job->delete();
     }
 }


### PR DESCRIPTION
This job removal is now done earlier so that exceptions thrown while processing the job don't cause us to forever queue jobs. An example of where this was rekt'ing when JOB_TOO_BIG errors are thrown during processing.
